### PR TITLE
Fix 500 error

### DIFF
--- a/docker/website/Dockerfile.production
+++ b/docker/website/Dockerfile.production
@@ -12,8 +12,8 @@ RUN npm run build-prod
 
 FROM nginx
 
-RUN mkdir /var/app && mkdir /var/app/build
-WORKDIR /var/app
+RUN mkdir -p /var/app/website
+WORKDIR /var/app/website
 
-COPY --from=build /var/app/website/dist /var/app/dist
+COPY --from=build /var/app/website/dist /var/app/website/dist
 COPY ./conf/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
The bedav website container copied the webpack builds to the wrong folder.